### PR TITLE
changed edstem link to campus wire

### DIFF
--- a/_data/sp25/course.yml
+++ b/_data/sp25/course.yml
@@ -2,7 +2,7 @@
 quarter: Spring 2025
 building: SOLIS 104
 timings: TUE & THUR 5:00PM - 6:20PM
-edstem_link: https://edstem.org/us/join/dtzKre
+edstem_link: https://campuswire.com/p/GE6841F89
 gradescope_link: https://www.gradescope.com/courses/1001291
 gradescope_entry_code: 
 


### PR DESCRIPTION
the tag (not sure what it's called in yml) is still edstem_link but it now brings you to the campuswire page